### PR TITLE
Bug fix for sample rate at 16 Hz

### DIFF
--- a/timeseries_features/fir.py
+++ b/timeseries_features/fir.py
@@ -36,18 +36,18 @@ def osem_position(osem_data, pad_sec=64, new_sample_rate=None):
     nyquist=osem_data.sample_rate.value/2.
     assert new_sample_rate >= 16
     result = fir_helper(osem_data,
-                        [0.,0.04/nyquist,0.08/nyquist,7.2/nyquist,8./nyquist,1.],
-                        [0.,1.e-4,1.,1.,1.e-6,0.],
+                        [0.,0.04/nyquist,0.08/nyquist,7.2/nyquist,1.],
+                        [0.,1.e-4,1.,1.,0.],
                         pad_sec=pad_sec,
                         new_sample_rate=new_sample_rate, deriv=False)
     return result
 
-def osem_velocity(osem_data, pad_sec=256, new_sample_rate=None):
+def osem_velocity(osem_data, pad_sec=64, new_sample_rate=None):
     nyquist=osem_data.sample_rate.value/2.
     assert new_sample_rate >= 16
     result = fir_helper(osem_data,
-                        [0.,0.04/nyquist,0.08/nyquist,7.2/nyquist,8./nyquist,1.],
-                        [0.,1.e-4,2.*pi*0.08,2.*pi*7.2,1.e-5,0.],
+                        [0.,0.04/nyquist,0.08/nyquist,7.2/nyquist,1.],
+                        [0.,1.e-4,2.*pi*0.08,2.*pi*7.2,0.],
                         pad_sec=pad_sec,
                         new_sample_rate=new_sample_rate, deriv=True)
     return result


### PR DESCRIPTION
There's a bug in the filter code when the sample rate is 16 Hz. This should fix it and fix the default length of the derivative filter.